### PR TITLE
Use TS 3.0 tuple/parameter types to clean API/typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5288,9 +5288,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://nexus.aws.averoinc.com/repository/npm-group/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.0.0-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.0-rc.tgz",
+      "integrity": "sha512-//6ivFupDRi+rtsivXnYNfXK7URxdvO18hhxgNpbiIVBE611+1NCiiEfgjjx53TU7fjxlhWPuv3RRj5hJF62/w==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typesafe-react-router",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5288,9 +5288,9 @@
       }
     },
     "typescript": {
-      "version": "3.0.0-rc",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.0-rc.tgz",
-      "integrity": "sha512-//6ivFupDRi+rtsivXnYNfXK7URxdvO18hhxgNpbiIVBE611+1NCiiEfgjjx53TU7fjxlhWPuv3RRj5hJF62/w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rollup": "^0.61.2",
     "rollup-plugin-uglify": "^4.0.0",
     "ts-jest": "^22.4.6",
-    "typescript": "^2.9.2"
+    "typescript": "^3.0.0-rc"
   },
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typesafe-react-router",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Type-safe helpers for React-Router",
   "main": "./dist/bundle.js",
   "types": "./dist/index.d.ts",
@@ -33,7 +33,10 @@
     "rollup": "^0.61.2",
     "rollup-plugin-uglify": "^4.0.0",
     "ts-jest": "^22.4.6",
-    "typescript": "^3.0.0-rc"
+    "typescript": "^3.0.1"
+  },
+  "peerDependencies": {
+    "typescript": "^3.0.0"
   },
   "jest": {
     "transform": {

--- a/src/route.test.ts
+++ b/src/route.test.ts
@@ -23,11 +23,11 @@ enum RouteNames {
 }
 
 const Routes = {
-  [RouteNames.HOME]: route(['home']),
-  [RouteNames.VIEW]: route(['view']),
-  [RouteNames.VIEW_DETAILS]: route(['view', param('id')]),
-  [RouteNames.VIEW_MORE_DETAILS]: route(['view', param('id'), 'more', param('otherId')]),
-  [RouteNames.ONLY_PARAM]: route([param('param')]),
+  [RouteNames.HOME]: route('home'),
+  [RouteNames.VIEW]: route('view'),
+  [RouteNames.VIEW_DETAILS]: route('view', param('id')),
+  [RouteNames.VIEW_MORE_DETAILS]: route('view', param('id'), 'more', param('otherId')),
+  [RouteNames.ONLY_PARAM]: route(param('param')),
 };
 
 const expectedTemplate = {

--- a/src/route.ts
+++ b/src/route.ts
@@ -11,95 +11,19 @@
    limitations under the License.
  */
 
-import { PathPart, Route } from './interfaces/types';
+import {
+  PathPart,
+  Route,
+  RouteParams,
+  OnlyParams,
+  ParamsFromPathArray,
+} from './interfaces/types';
 import { isParam } from './interfaces/guards';
+import { param } from './param';
 
-export interface RouteCreator {
-  <K extends PathPart<any>>(ks: [K]): Route<K>;
-  <K extends PathPart<any>, K1 extends PathPart<string>>(ks: [K, K1]): Route<K | K1>;
-  <K extends PathPart<any>, K1 extends PathPart<any>, K2 extends PathPart<any>>(
-    ks: [K, K1, K2]
-  ): Route<K | K1 | K2>;
-  <
-    K extends PathPart<any>,
-    K1 extends PathPart<any>,
-    K2 extends PathPart<any>,
-    K3 extends PathPart<any>
-  >(
-    ks: [K, K1, K2, K3]
-  ): Route<K | K1 | K2 | K3>;
-  <
-    K extends PathPart<any>,
-    K1 extends PathPart<any>,
-    K2 extends PathPart<any>,
-    K3 extends PathPart<any>,
-    K4 extends PathPart<any>
-  >(
-    ks: [K, K1, K2, K3, K4]
-  ): Route<K | K1 | K2 | K3 | K4>;
-  <
-    K extends PathPart<any>,
-    K1 extends PathPart<any>,
-    K2 extends PathPart<any>,
-    K3 extends PathPart<any>,
-    K4 extends PathPart<any>,
-    K5 extends PathPart<any>
-  >(
-    ks: [K, K1, K2, K3, K4, K5]
-  ): Route<K | K1 | K2 | K3 | K4 | K5>;
-  <
-    K extends PathPart<any>,
-    K1 extends PathPart<any>,
-    K2 extends PathPart<any>,
-    K3 extends PathPart<any>,
-    K4 extends PathPart<any>,
-    K5 extends PathPart<any>,
-    K6 extends PathPart<any>
-  >(
-    ks: [K, K1, K2, K3, K4, K5, K6]
-  ): Route<K | K1 | K2 | K3 | K4 | K5 | K6>;
-  <
-    K extends PathPart<any>,
-    K1 extends PathPart<any>,
-    K2 extends PathPart<any>,
-    K3 extends PathPart<any>,
-    K4 extends PathPart<any>,
-    K5 extends PathPart<any>,
-    K6 extends PathPart<any>,
-    K7 extends PathPart<any>
-  >(
-    ks: [K, K1, K2, K3, K4, K5, K6, K7]
-  ): Route<K | K1 | K2 | K3 | K4 | K5 | K6 | K7>;
-  <
-    K extends PathPart<any>,
-    K1 extends PathPart<any>,
-    K2 extends PathPart<any>,
-    K3 extends PathPart<any>,
-    K4 extends PathPart<any>,
-    K5 extends PathPart<any>,
-    K6 extends PathPart<any>,
-    K7 extends PathPart<any>,
-    K8 extends PathPart<any>
-  >(
-    ks: [K, K1, K2, K3, K4, K5, K6, K7, K8]
-  ): Route<K | K1 | K2 | K3 | K4 | K5 | K6 | K7 | K8>;
-  <
-    K extends PathPart<any>,
-    K1 extends PathPart<any>,
-    K2 extends PathPart<any>,
-    K3 extends PathPart<any>,
-    K4 extends PathPart<any>,
-    K5 extends PathPart<any>,
-    K6 extends PathPart<any>,
-    K7 extends PathPart<any>,
-    K8 extends PathPart<any>,
-    K9 extends PathPart<any>
-  >(
-    ks: [K, K1, K2, K3, K4, K5, K6, K7, K8, K9]
-  ): Route<K | K1 | K2 | K3 | K4 | K5 | K6 | K7 | K8 | K9>;
-}
+export type RouteCreator = <K extends Array<PathPart<any>>>(...args: K) => Route<K>;
 
-export const route: RouteCreator = (pathParts: Array<PathPart<any>>) => {
+export const route: RouteCreator = (...pathParts: Array<PathPart<any>>) => {
   return {
     template: () => {
       return (
@@ -122,3 +46,11 @@ export const route: RouteCreator = (pathParts: Array<PathPart<any>>) => {
     },
   };
 };
+
+const routes = {
+  LOGIN: route('login'),
+  VIEW: route('view'),
+  VIEW_DETAILS: route('view', param('details'), param('another')),
+};
+
+const b = routes.VIEW_DETAILS.create({ details: '0' });

--- a/src/route.ts
+++ b/src/route.ts
@@ -11,13 +11,7 @@
    limitations under the License.
  */
 
-import {
-  PathPart,
-  Route,
-  RouteParams,
-  OnlyParams,
-  ParamsFromPathArray,
-} from './interfaces/types';
+import { PathPart, Route, RouteParams, ParamsFromPathArray } from './interfaces/types';
 import { isParam } from './interfaces/guards';
 import { param } from './param';
 
@@ -46,11 +40,3 @@ export const route: RouteCreator = (...pathParts: Array<PathPart<any>>) => {
     },
   };
 };
-
-const routes = {
-  LOGIN: route('login'),
-  VIEW: route('view'),
-  VIEW_DETAILS: route('view', param('details'), param('another')),
-};
-
-const b = routes.VIEW_DETAILS.create({ details: '0' });


### PR DESCRIPTION
TypeScript 3.0 included some new features around handling [parameter lists](https://blogs.msdn.microsoft.com/typescript/2018/07/30/announcing-typescript-3-0/#tuples-and-parameters). With these changes, we can cleanup both the API and overloads related to our `RouteCreator` type. 

This is a MAJOR breaking change, as we now accept spread arguments instead of a tuple/array:
`const route = route(['view', 'details', param('id')])` 
becomes 
`const route = route('view', 'details', param('id'))` 