### PR TITLE
Implement .nest() to extend the routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of types and utility functions to facilitate typesafe routing in Re
 `npm i typesafe-react-router`
 
 ![vscode](https://i.imgur.com/WQHOWKx.gif "VSCode")
-Note: This gif is using the 1.0 array-style API, rather than spread arguments used in 2.0. 
+Note: This gif is using the 1.0 array-style API, rather than spread arguments used in 2.0.
 
 ## Usage
 
@@ -19,13 +19,24 @@ export enum RouteNames {
 }
 
 export const Routes = {
-  [RouteNames.HOME]: route('home');
-  [RouteNames.VIEW_ALL]: route('view')
-  [RouteNames.VIEW_DETAILS]: route('view', param('id'))
+  [RouteNames.HOME]: route('home'),
+  [RouteNames.VIEW_ALL]: route('view'),
+  [RouteNames.VIEW_DETAILS]: route('view', param('id')),
+  [RouteNames.CONTACTS]: route('contacts'),
+  get [RouteNames.ADD_CONTACT]() {
+    return this[RouteNames.CONTACTS].nest('add')
+  },
+  get [RouteNames.VIEW_CONTACT]() {
+    return this[RouteNames.CONTACTS].nest(param('id'))
+  }
 }
 
 const viewDetailsTemplate = Routes[RouteNames.VIEW_DETAILS].template() // -> /view/:id
 const viewDetailsCreate = Routes[RouteNames.VIEW_DETAILS].create({ id: '2' }) // -> /view/2
+
+const addContactTemplate = Routes[RouteNames.ADD_CONTACT].template() // -> /contacts/add
+const viewContactTemplate = Routes[RouteNames.VIEW_CONTACT].template() // -> /contacts/:id
+const viewContactCreate = Routes[RouteNames.VIEW_CONTACT].create({id: '4'}) // -> /contacts/4
 
 const viewDetailsCreateERROR = Routes[RouteNames.VIEW_DETAILS].create({}) // ERROR: property 'id' is missing in type {}
 

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -30,6 +30,7 @@ export interface Route<
   ) => Route<Parts, [QueryParams[number] | T[number]]>;
 
   parse(queryString: string): Partial<Record<QueryParams[number], string>>;
+  nest(): Route<Parts, QueryParams>
 }
 
 export interface PathParam<T extends string> {

--- a/src/route.test.ts
+++ b/src/route.test.ts
@@ -172,4 +172,10 @@ describe('Route', () => {
       garbage2: '2/1/2018',
     });
   });
+
+  test('extend', () => {
+    Object.keys(Routes).forEach(k => {
+      expect(Routes[k].nest('new', param('param')).template()).toEqual(`${expectedTemplate[k]}/new/:param`);
+    });
+  })
 });

--- a/src/route.ts
+++ b/src/route.ts
@@ -68,5 +68,8 @@ function _routeCreator<T extends Array<PathPart<any>>, Q extends Array<string> =
     parse: (queryString: string) => {
       return _parse(queryString);
     },
+    nest: (...morePathParts: Array<PathPart<any>>) => {
+      return _routeCreator([...pathParts, ...morePathParts], queryParams)
+    }
   };
 }


### PR DESCRIPTION
Sometimes it might be required to create a route (say `extended route`) that might be an extension of another route (say `original route`). The proposed `nest()` function provides a way to do the same without having to repeat the params passed to the `original route`.

Example usage of this function is provided in the `README.md`.

Please feel free to reach out to me@goje87.com if required. 